### PR TITLE
fix: Add homeUrl to some links

### DIFF
--- a/templates/plist.html
+++ b/templates/plist.html
@@ -39,19 +39,19 @@
     {%- endif -%}
 </h1>
 <div class="title-right">
-    <a href="/tag.html"><button id="buttonSearch" class="btn btn-invisible circle" title="{{ i18n['Search'] }}">
+    <a href="{{ blogBase['homeUrl'] }}/tag.html"><button id="buttonSearch" class="btn btn-invisible circle" title="{{ i18n['Search'] }}">
         <svg class="octicon" width="16" height="16" >
             <path id="pathSearch" fill-rule="evenodd"></path>
         </svg>
     </button></a>
     {% for num in blogBase['singeListJson'] -%}
-    <a href="/{{ blogBase['singeListJson'][num]['label'] }}.html"><button class="btn btn-invisible circle" title="{{ blogBase['singeListJson'][num]['postTitle'] }}">
+    <a href="{{ blogBase['homeUrl'] }}/{{ blogBase['singeListJson'][num]['label'] }}.html"><button class="btn btn-invisible circle" title="{{ blogBase['singeListJson'][num]['postTitle'] }}">
         <svg class="octicon" width="16" height="16" >
             <path id="{{ blogBase['singeListJson'][num]['postTitle'] }}" fill-rule="evenodd"></path>
         </svg>
     </button></a>
     {%- endfor %}
-    <a href="/rss.xml" target="_blank"><button id="buttonRSS" class="btn btn-invisible circle" title="RSS">
+    <a href="{{ blogBase['homeUrl'] }}/rss.xml" target="_blank"><button id="buttonRSS" class="btn btn-invisible circle" title="RSS">
         <svg class="octicon" width="16" height="16" >
             <path id="pathRSS" fill-rule="evenodd"></path>
         </svg>
@@ -76,7 +76,7 @@
     </div>
     <div class="listLabels">
         {% if postListJson[num]['commentNum']>0 %}<span class="Label" style="background-color:{{ blogBase['commentLabelColor'] }}">{{ postListJson[num]['commentNum'] }}</span>{% endif %}
-        <span class="Label LabelName" style="background-color:{{ postListJson[num]['labelColor'] }}"><object><a style="color:#fff" href="/tag.html#{{ postListJson[num]['label'] }}">{{ postListJson[num]['label'] }}</a></object></span>
+        <span class="Label LabelName" style="background-color:{{ postListJson[num]['labelColor'] }}"><object><a style="color:#fff" href="{{ blogBase['homeUrl'] }}/tag.html#{{ postListJson[num]['label'] }}">{{ postListJson[num]['label'] }}</a></object></span>
         <span class="Label LabelTime" style="background-color:{{ postListJson[num]['dateLabelColor'] }}">{{ postListJson[num]['createdDate'] }}</span>
     </div>
 </a>
@@ -88,13 +88,13 @@
         {%- if blogBase['prevUrl']=='disabled' -%}
         <span class="previous_page" aria-disabled="true">{{ i18n['Previous'] }}</span>
         {% else -%}
-        <a class="previous_page" rel="previous" href="{{ blogBase['prevUrl'] }}" aria-label="Previous Page">{{ i18n['Previous'] }}</a>
+        <a class="previous_page" rel="previous" href="{{ blogBase['homeUrl'] }}{{ blogBase['prevUrl'] }}" aria-label="Previous Page">{{ i18n['Previous'] }}</a>
         {%- endif -%}
 
         {%- if blogBase['nextUrl']=='disabled' -%}
         <span class="next_page" aria-disabled="true">{{ i18n['Next'] }}</span>
         {% else -%}
-        <a class="next_page" rel="next" href="{{ blogBase['nextUrl'] }}" aria-label="Next Page">{{ i18n['Next'] }}</a>
+        <a class="next_page" rel="next" href="{{ blogBase['homeUrl'] }}{{ blogBase['nextUrl'] }}" aria-label="Next Page">{{ i18n['Next'] }}</a>
         {%- endif -%}
 
     </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -27,7 +27,7 @@
 <span class="postTitle">{{ blogBase['postTitle'] }}</span>
 <div class="title-right">
 
-    <a href="/"><button id="buttonHome" class="btn btn-invisible circle" title="{{ i18n['home'] }}">
+    <a href="{{ blogBase['homeUrl'] }}"><button id="buttonHome" class="btn btn-invisible circle" title="{{ i18n['home'] }}">
         <svg class="octicon" width="16" height="16">
             <path id="pathHome" fill-rule="evenodd" d="{{ IconList['home'] }}"></path>
         </svg>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -38,7 +38,7 @@
             <path id="searchSVG" fill-rule="evenodd" d=""></path>
         </svg>
     </div>
-    <a href="/"><button id="buttonHome" class="btn btn-invisible circle" title="{{ i18n['home'] }}">
+    <a href="{{ blogBase['homeUrl'] }}"><button id="buttonHome" class="btn btn-invisible circle" title="{{ i18n['home'] }}">
         <svg class="octicon" width="16" height="16">
             <path id="pathHome" fill-rule="evenodd" d="{{ IconList['home'] }}"></path>
         </svg>


### PR DESCRIPTION
若部署的環境是使用子資料夾的情況，某些連結因為是使用開頭` / `，即沒有指定域名的情況，就會連到錯誤的位址了，故將`{{ blogBase['homeUrl'] }}`加入到目前會有問題的連結。

請幫忙看看這樣修改是否合適，感謝。