### PR TITLE
feat: 优化首页的用户头像图片的展示比例

### DIFF
--- a/templates/plist.html
+++ b/templates/plist.html
@@ -6,7 +6,7 @@
 
 {% block style %}
 <style>
-.avatar {transition: 0.8s;width:64px;height:64px;}
+.avatar {transition: 0.8s;width:64px;height:64px;object-fit: cover;}
 .avatar:hover{transform: scale(1.15) rotate(360deg);}
 #header h1 a{color:inherit;text-decoration:none;vertical-align: bottom;font-size:40px;font-family:Monaco;margin-left:8px;}
 .title-right{display:flex;margin:auto 0 0 auto;}


### PR DESCRIPTION
当用户配置的头像图片，不是 1：1比例的时候，图片会被拉伸。