### PR TITLE
fix: 修复编辑issue内容后触发workflow时报[KeyError: 'ogImage']的错误

### DIFF
--- a/Gmeek.py
+++ b/Gmeek.py
@@ -460,7 +460,9 @@ for i in blog.blogBase["postListJson"]:
     del blog.blogBase["postListJson"][i]["script"]
     del blog.blogBase["postListJson"][i]["style"]
     del blog.blogBase["postListJson"][i]["top"]
-    del blog.blogBase["postListJson"][i]["ogImage"]
+
+    if 'ogImage' in blog.blogBase["postListJson"][i]:
+        del blog.blogBase["postListJson"][i]["ogImage"]
 
     if 'commentNum' in blog.blogBase["postListJson"][i]:
         commentNumSum=commentNumSum+blog.blogBase["postListJson"][i]["commentNum"]


### PR DESCRIPTION
如题：在二次编辑issue的内容重新保存后会触发workflow，其中Gmeek.py第463行会报key error
```
GitHub Pages URL:  https://wuyiwai.github.io
Traceback (most recent call last):
  File "Gmeek.py", line 463, in <module>
    del blog.blogBase["postListJson"][i]["ogImage"]
KeyError: 'ogImage'
blogBase is exists and issue_number!=0, runOne
====== start create static html ======
create postPage title=2024年5月见闻 file=docs/post/2024-nian-5-yue-jian-wen.html 
topNum=0 postNum=2
create docs/index.html
create tag.html
```