### PR TITLE
增加 `disableCamo` 配置项，以支持图片可使用创建文章(issue)时输入的原始链接。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 nohup.out
 .git-credentials
 venv/
+.idea

--- a/Gmeek.py
+++ b/Gmeek.py
@@ -86,7 +86,7 @@ class GMEEK():
             print("static does not exist")
 
     def defaultConfig(self):
-        dconfig={"singlePage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":+8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":"","disableCamo":0}
+        dconfig={"singlePage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":+8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":"","disableCamo":0,"backgroundImageUrl":""}
         config=json.loads(open('config.json', 'r', encoding='utf-8').read())
         self.blogBase={**dconfig,**config}.copy()
         self.blogBase["postListJson"]=json.loads('{}')

--- a/Gmeek.py
+++ b/Gmeek.py
@@ -86,7 +86,7 @@ class GMEEK():
             print("static does not exist")
 
     def defaultConfig(self):
-        dconfig={"singlePage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":+8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":""}
+        dconfig={"singlePage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":+8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":"","disableCamo":0}
         config=json.loads(open('config.json', 'r', encoding='utf-8').read())
         self.blogBase={**dconfig,**config}.copy()
         self.blogBase["postListJson"]=json.loads('{}')
@@ -159,6 +159,8 @@ class GMEEK():
         return a_tag + img_tag
 
     def process_html_img_src(self, origin_html):
+        if self.blogBase["disableCamo"] != 1:
+            return origin_html
         # 使用正则表达式查找并替换符合条件的标签
         pattern = r'(<a[^>]*>)(<img[^>]*data-canonical-src[^>]*>)'
         processed_html = re.sub(pattern, self.replace_canonical_attributes, origin_html)

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,8 +16,8 @@
     {% block head %}{% endblock %}
 </head>
 <style>
-html{background-image: url("{{ blogBase['backgroundImageUrl'] }}");background-repeat: no-repeat;background-size: cover;}
-body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;padding: 45px;font-size: 16px;font-family: sans-serif;line-height: 1.25;}
+html{background-image: url("{{ blogBase['backgroundImageUrl'] }}");background-repeat: no-repeat;background-size: cover;background-attachment: fixed;}
+body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;padding: 45px;font-size: 16px;font-family: sans-serif;line-height: 1.25;background-color: unset;}
 #header{display:flex;padding-bottom:8px;border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted));margin-bottom: 16px;}
 #footer {margin-top:64px; text-align: center;font-size: small;}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
     {% block head %}{% endblock %}
 </head>
 <style>
+html{background-image: url("{{ blogBase['backgroundImageUrl'] }}");background-repeat: no-repeat;background-size: cover;}
 body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;padding: 45px;font-size: 16px;font-family: sans-serif;line-height: 1.25;}
 #header{display:flex;padding-bottom:8px;border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted));margin-bottom: 16px;}
 #footer {margin-top:64px; text-align: center;font-size: small;}

--- a/templates/plist.html
+++ b/templates/plist.html
@@ -18,9 +18,9 @@
 .title-right button{margin-right:8px;padding:16px;}
 .title-right .circle{padding: 14px 16px;}
 
-.SideNav{min-width: 360px;}
+.SideNav{min-width: 360px;background-color: unset;}
 .SideNav-icon{margin-right: 16px}
-.SideNav-item .Label{color: #fff;margin-left:4px;}
+.SideNav-item .Label{color: #fff;margin-left:4px;border-radius: unset;}
 .d-flex{min-width:0;}
 .listTitle{overflow:hidden;white-space:nowrap;text-overflow: ellipsis;max-width: 100%;}
 .listLabels{white-space:nowrap;display:flex;}
@@ -92,9 +92,9 @@
     <div class="listLabels">
         {% if postListJson[num]['commentNum']>0 %}<span class="Label" style="background-color:{{ blogBase['commentLabelColor'] }}">{{ postListJson[num]['commentNum'] }}</span>{% endif %}
         {% for label in postListJson[num]['labels'] -%}
-        <span class="Label LabelName" style="background-color:{{ blogBase['labelColorDict'][label] }}"><object><a style="color:#fff" href="tag.html#{{ label }}">{{ label }}</a></object></span>
+        <span class="Label LabelName" {#style="background-color:{{ blogBase['labelColorDict'][label] }}"#}><object><a style="color:#fff" href="tag.html#{{ label }}">{{ label }}</a></object></span>
         {%- endfor %}
-        <span class="Label LabelTime" style="background-color:{{ postListJson[num]['dateLabelColor'] }}">{{ postListJson[num]['createdDate'] }}</span>
+        <span class="Label LabelTime" {#style="background-color:{{ postListJson[num]['dateLabelColor'] }}"#}>{{ postListJson[num]['createdDate'] }}</span>
     </div>
 </a>
 {%- endfor %}


### PR DESCRIPTION
增加 `disableCamo` 配置项，控制文章中的图片是否使用创建文章(issue)时输入的原始链接。
背景：
1. Gmeek 使用了 GitHub API 将 markdown 渲染为 html；
2. 而在这个过程 GitHub 会使用开源项目 Camo 将 markdown 中的图片进行托管；
3. Camo 会为每幅图像生成开头为 https://camo.githubusercontent.com/ 的匿名 URL 代理；

Github 这么做的理由是：
1. 代理这些图像将有助于保护用户的隐私：用户访问这些图片时，浏览器信息不会泄露给第三方服务；
2. Github 通过 CDN 加速图像的访问；
3. 有 CDN 可以减少因原始图片链接失效而无法正常渲染的情况；

然而如果你的图片本身托管在国内，GitHub 这么做反而会降低图片的访问速度，甚至导致无法访问(不能科学上网时)。
因此，增加一个单独的配置项，如果配置了 `"disableCamo": 1`，Gmeek 会在 GitHub 渲染网页后将图片链接简单替换为原始链接。

参考：
> https://docs.github.com/zh/authentication/keeping-your-account-and-data-secure/about-anonymized-urls
> https://github.blog/news-insights/product-news/proxying-user-images/